### PR TITLE
Inserted SUBMODULES to analyse all .sv files

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,11 +1,11 @@
 .DEFAULT_GOAL := all
 
-simulation: $(FILE).sv $(FILE)_tb.sv
-	iverilog -g2012  -o test_pre $(FILE).sv $(FILE)_tb.sv
+simulation: $(FILE).sv $(FILE)_tb.sv $(SUBMODULES)
+	iverilog -g2012  -o test_pre $(FILE).sv $(FILE)_tb.sv $(SUBMODULES)
 	vvp test_pre
 
 synthesis: $(FILE).sv
-	yosys -p '$(TARGET) -top $(FILE); write_json $(FILE).json; show -format svg -prefix $(FILE)_yosys;' $(FILE).sv
+	yosys -p '$(TARGET) -top $(FILE); write_json $(FILE).json; show -format svg -prefix $(FILE)_yosys $(FILE);' $(FILE).sv $(SUBMODULES)
 
 visualize:
 	sed -i -e 's/inout/output/g' $(FILE).json

--- a/rslatch/Makefile
+++ b/rslatch/Makefile
@@ -1,5 +1,6 @@
 FILE=rslatch
 #TARGET=synth
 TARGET=synth_ice40
+#SUBMODULES=sub1.sv sub2.sv ...
 
 include ../Makefile.inc


### PR DESCRIPTION
The SUBMODULES variable holds the filenames of all modules that are not the toplevel module. This avoids the parser errors when otherwise using *.sv to import all source files, which would also import the testbench(es)