### PR TITLE
add .svlangserver to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.dot
 test_pre
 .DS_Store
+.svlangserver


### PR DESCRIPTION
The `.svlangserver` directory seems to be created by the svlangserver Verilog LSP server which is used by the the Helix editor. Alternatively I could also add this to my local gitignore.